### PR TITLE
change geodecoder in Plugins.qml 

### DIFF
--- a/qml/pages/Plugin/Plugin.qml
+++ b/qml/pages/Plugin/Plugin.qml
@@ -106,7 +106,7 @@ Dialog {
     }
     function getItemsByAddress(country, callback) {
         var req = new XMLHttpRequest()
-        req.open( "GET", "http://maps.googleapis.com/maps/api/geocode/json?address="+address+"&region="+country )
+        req.open( "GET", "https://nominatim.openstreetmap.org/search?format=json&street="+address+"&city="+city+"&country="+country )
         req.onreadystatechange = function() {
             if( req.readyState == 4 && !useGps ) {
                 try {


### PR DESCRIPTION
The currently used google geodecoder seems to be disfunct. In this PR it is replaced by the openstreetmap decoder. However, this also requires to split the former address variable into two, one for the street and one for the city.